### PR TITLE
feat(cli): add the deploy webresources command

### DIFF
--- a/src/XrmFramework.Cli/Commands/DeployWebResourcesCommand.cs
+++ b/src/XrmFramework.Cli/Commands/DeployWebResourcesCommand.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Christophe Gondouin (CGO Conseils). All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using XrmFramework.DeployUtils;
+using XrmFramework.DeployUtils.Configuration;
+
+namespace XrmFramework.Cli.Commands;
+
+/// <summary>
+/// <c>xrmframework deploy webresources</c> command: publishes the web resources found under
+/// <c>--path</c> (or auto-discovered from a folder named after <c>--project</c>) to the
+/// environment selected in <c>Config/xrmFramework.config</c>. Delegates to
+/// <see cref="WebResourceHelper.SyncWebResources(string, string, bool)" />.
+/// </summary>
+public sealed class DeployWebResourcesCommand : Command<DeployWebResourcesCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandOption("--project <NAME>")]
+        [System.ComponentModel.Description("Project name as declared in xrmFramework.config (e.g. Webresources).")]
+        public string? Project { get; init; }
+
+        [CommandOption("--path <DIR>")]
+        [System.ComponentModel.Description("Webresources project folder (default: auto-discovered from a folder named after --project).")]
+        public string? Path { get; init; }
+
+        [CommandOption("--project-root <DIR>")]
+        [System.ComponentModel.Description("Project root containing the Config/ folder (default: current folder).")]
+        public string ProjectRoot { get; init; } = ".";
+
+        // -NoPrompt is accepted too, for the scripts written against that spelling: Program.cs
+        // rewrites it to --noprompt before Spectre parses, a short option name being limited to
+        // one character.
+        [CommandOption("-n|--noprompt")]
+        [System.ComponentModel.Description("Silent mode: skips the connection confirmation (CI/CD). Also accepts -NoPrompt.")]
+        public bool NoPrompt { get; init; }
+
+        public override ValidationResult Validate()
+        {
+            if (string.IsNullOrWhiteSpace(Project))
+                return ValidationResult.Error("The --project option is required.");
+
+            if (!string.IsNullOrWhiteSpace(Path) && !Directory.Exists(Path))
+                return ValidationResult.Error($"Directory not found: {Path}");
+
+            return ValidationResult.Success();
+        }
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        ConfigHelper.UseProjectConfig(Path.GetFullPath(settings.ProjectRoot));
+
+        WebResourceHelper.SyncWebResources(settings.Project!, settings.Path!, settings.NoPrompt);
+
+        return 0;
+    }
+}

--- a/src/XrmFramework.Cli/Program.cs
+++ b/src/XrmFramework.Cli/Program.cs
@@ -15,6 +15,7 @@ using XrmFramework.DeployUtils.CommandOptions;
 //   xrmframework tables optionsets list [--option <logicalname>] [--filter <text>] [--global-only]
 //   xrmframework tables optionsets set  --option <logicalname> [--name <newname>] [--value <n> --value-name <newname>]
 //   xrmframework deploy plugins         --dll <path.dll> --project <name> [--on-premise] [--noprompt]
+//   xrmframework deploy webresources    --project <name> [--path <directory>] [--noprompt]
 //   xrmframework migrate sync-tables    --dll <path.dll> --tables-dir <directory> [--clean]   (2.* -> 3.1+ migration)
 
 // A Windows console still starts on a legacy code page (CP850 / CP1252). Those cover Western
@@ -93,6 +94,11 @@ app.Configure(config =>
         deploy.AddCommand<DeployPluginsCommand>("plugins")
               .WithDescription("Deploys an assembly (plugins, custom APIs, workflows) to the selected environment.")
               .WithExample("deploy", "plugins", "--dll", "bin/net8.0/MyProject.Plugins.dll", "--project", "Plugins");
+
+        deploy.AddCommand<DeployWebResourcesCommand>("webresources")
+              .WithDescription("Publishes a project's web resources (html, css, js, images...) to the selected environment.")
+              .WithExample("deploy", "webresources", "--project", "Webresources")
+              .WithExample("deploy", "webresources", "--project", "Webresources", "--path", "Webresources");
     });
 
     // One-shot upgrades, as opposed to the day-to-day loop the other branches serve: each command

--- a/src/XrmFramework.DeployUtils/WebResourceHelper.cs
+++ b/src/XrmFramework.DeployUtils/WebResourceHelper.cs
@@ -40,6 +40,20 @@ public static class WebResourceHelper
                 }
             });
 
+        SyncWebResources(projectName, options.Path, options.DisablePrompt);
+    }
+
+    /// <summary>
+    ///     Publishes the web resources found under <paramref name="webresourcesPath" /> (or, when
+    ///     omitted, auto-discovered from a folder named <paramref name="projectName" /> walked up from
+    ///     the current directory) to the CRM solution declared for <paramref name="projectName" /> in
+    ///     <c>xrmFramework.config</c>.
+    /// </summary>
+    /// <param name="projectName">Name of the project as declared in <c>xrmFramework.config</c> (e.g. <c>"Webresources"</c>).</param>
+    /// <param name="webresourcesPath">Webresources project folder. Auto-discovered when <see langword="null" /> or empty.</param>
+    /// <param name="noPrompt">Silent mode: skips the interactive connection confirmation (CI/CD).</param>
+    public static void SyncWebResources(string projectName, string webresourcesPath, bool noPrompt)
+    {
         var nbWebresources = 0;
 
         var xrmFrameworkConfigSection = ConfigHelper.GetSection();
@@ -47,8 +61,8 @@ public static class WebResourceHelper
         var solutionName = xrmFrameworkConfigSection.Projects.OfType<ProjectElement>().Single(p => p.Name == projectName).TargetSolution;
 
         var connectionString = ConfigurationManager.ConnectionStrings[xrmFrameworkConfigSection.SelectedConnection].ConnectionString;
-            
-        if (!options.DisablePrompt)
+
+        if (!noPrompt)
         {
             Console.WriteLine($@"You are about to deploy on {connectionString} organization. If ok press any key.");
             Console.ReadKey();
@@ -132,8 +146,6 @@ public static class WebResourceHelper
         }
         var prefix = publisher.GetAttributeValue<string>("customizationprefix");
         Console.WriteLine(@" ==> Prefix : {0}", prefix);
-
-        var webresourcesPath = options.Path;
 
         if (string.IsNullOrWhiteSpace(webresourcesPath))
         {


### PR DESCRIPTION
Exposes web resource publishing (previously only reachable via the per-project Deploy.Webresources console template) as `xrmframework deploy webresources`, mirroring `deploy plugins`. WebResourceHelper.SyncWebResources gains a typed overload so the command can call it directly instead of round-tripping through CommandLine-parsed args.