### PR TITLE
feat(cli): full-screen interactive editor for .table files (tables edit)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,6 +86,15 @@
     <Ver_SpectreConsole>0.55.2</Ver_SpectreConsole>
     <Ver_SpectreConsoleCli>0.55.0</Ver_SpectreConsoleCli>
     <Ver_SpectreConsoleAnalyzer>1.0.0</Ver_SpectreConsoleAnalyzer>
+    <!--
+      CLI-only TUI (xrmframework tables edit), confined to XrmFramework.Cli.
+      Deliberately on the 1.x line rather than "latest": 2.0.1+ reorganized the entire public API
+      (Toplevel/View/Application replaced by an IRunnable/SessionToken session model) and is still
+      settling — prereleases were shipping days before this was written. 1.19.0 ships a net8.0
+      asset (consumed by our net10.0 TFM), is cross-platform (Windows/macOS/Linux drivers), and is
+      the long-stable, widely-deployed API this code is written against.
+    -->
+    <Ver_TerminalGui>1.19.0</Ver_TerminalGui>
 
     <!-- ═══════════════════════════════════════════════════════════
          Azure / Networking
@@ -161,6 +170,7 @@
     <PackageVersion Include="Spectre.Console"           Version="$(Ver_SpectreConsole)" />
     <PackageVersion Include="Spectre.Console.Cli"       Version="$(Ver_SpectreConsoleCli)" />
     <PackageVersion Include="Spectre.Console.Analyzer"  Version="$(Ver_SpectreConsoleAnalyzer)" />
+    <PackageVersion Include="Terminal.Gui"              Version="$(Ver_TerminalGui)" />
 
     <!-- Azure / Networking -->
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(Ver_SignalRClient)" />

--- a/src/XrmFramework.Cli/Commands/TableEditCommand.cs
+++ b/src/XrmFramework.Cli/Commands/TableEditCommand.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Christophe Gondouin (CGO Conseils). All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using Spectre.Console.Cli;
+using XrmFramework.Cli.Tui;
+
+namespace XrmFramework.Cli.Commands;
+
+/// <summary>
+/// <c>xrmframework tables edit</c> command: launches a full-screen, interactive editor over
+/// the locally tracked <c>.table</c> files — entirely offline, no environment connection.
+/// The console UI lives in <see cref="TableEditorApp" /> / <see cref="TableEditorWindow" />.
+/// </summary>
+public sealed class TableEditCommand : Command<TableEditCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        // Fully qualified attributes: a global MSTest using (transitive via DeployUtils)
+        // makes [Description] ambiguous with UnitTesting.DescriptionAttribute.
+        [CommandOption("--tables-dir <DIRECTORY>")]
+        [System.ComponentModel.Description("Directory holding the .table files (default: the Core project's Definitions folder).")]
+        public string? TablesDirectory { get; init; }
+
+        [CommandOption("--project-root <DIR>")]
+        [System.ComponentModel.Description("Root containing the Config/ folder (default: search by walking up from the current folder).")]
+        public string? ProjectRoot { get; init; }
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+        => TableEditorApp.Run(settings.ProjectRoot, settings.TablesDirectory);
+}

--- a/src/XrmFramework.Cli/Program.cs
+++ b/src/XrmFramework.Cli/Program.cs
@@ -12,6 +12,7 @@ using XrmFramework.DeployUtils.CommandOptions;
 //   xrmframework tables columns list    [--table <name>] [--prefix <prefix>] [--filter <text>] [--unselected-only]
 //   xrmframework tables columns add     --table <name> --column <name> | --all [--noprompt]
 //   xrmframework tables columns set     --table <name> --column <name> [--name <newname>] [--select|--deselect]
+//   xrmframework tables edit            [--tables-dir <directory>]   (full-screen interactive editor)
 //   xrmframework tables optionsets list [--option <logicalname>] [--filter <text>] [--global-only]
 //   xrmframework tables optionsets set  --option <logicalname> [--name <newname>] [--value <n> --value-name <newname>]
 //   xrmframework deploy plugins         --dll <path.dll> --project <name> [--on-premise] [--noprompt]
@@ -70,6 +71,10 @@ app.Configure(config =>
                    .WithDescription("Renames a column's C# name and/or toggles its selection in a .table file.")
                    .WithExample("tables", "columns", "set", "--table", "ftp_contrat", "--column", "ftp_datedebut", "--name", "DateDebut");
         });
+
+        tables.AddCommand<TableEditCommand>("edit")
+              .WithDescription("Full-screen interactive editor: browse tracked tables, toggle columns, rename them. Same edits as 'columns add/set', without needing table/column names on the command line.")
+              .WithExample("tables", "edit");
 
         tables.AddBranch("optionsets", optionsets =>
         {

--- a/src/XrmFramework.Cli/README.md
+++ b/src/XrmFramework.Cli/README.md
@@ -299,6 +299,37 @@ Implementation: [`ColumnHelper`](../XrmFramework.DeployUtils/TableSync/ColumnHel
 -> [`TableFileStore`](../XrmFramework.DeployUtils/TableSync/TableFileStore.cs)
 + [`ProjectConfigLocator`](../XrmFramework.DeployUtils/TableSync/ProjectConfigLocator.cs).
 
+### `xrmframework tables edit` ✅ *(available)* — full-screen interactive editor
+
+The interactive counterpart of `tables columns add`/`set`: a full-screen, keyboard-driven
+console UI ([Terminal.Gui](https://github.com/gui-cs/Terminal.Gui)) over the locally tracked
+`.table` files, for when you'd rather browse than remember exact table/column logical names.
+Entirely offline, same [`TableFileStore`](../XrmFramework.DeployUtils/TableSync/TableFileStore.cs)
+as every other `tables` command underneath.
+
+```
+xrmframework tables edit [--tables-dir <DIRECTORY>] [--project-root <DIR>]
+```
+
+Tables tracked locally on the left, the columns of whichever one is selected on the right:
+
+| Key | Action |
+|---|---|
+| `↑` / `↓`, `Tab` | Navigate / switch pane |
+| `Space`, `Enter` | Toggle the selected column's `Select` flag |
+| `R` | Rename the selected column's C# name |
+| `Esc`, `Q` | Quit |
+
+Every toggle or rename is validated (same duplicate-name rule as `columns set --name`) and saved
+to disk immediately — there is no separate save step.
+
+Requires a real terminal (not redirected output); on an unsupported terminal, prefer the
+non-interactive `tables columns`/`tables optionsets` commands.
+
+Implementation: [`TableEditorApp` / `TableEditorWindow`](Tui)
+-> [`TableFileStore`](../XrmFramework.DeployUtils/TableSync/TableFileStore.cs)
++ [`ProjectConfigLocator`](../XrmFramework.DeployUtils/TableSync/ProjectConfigLocator.cs).
+
 ### `xrmframework tables optionsets` ✅ *(available)* — rename option sets and their members
 
 The companion of `tables columns` for option sets: renames an option set's C# name and/or one

--- a/src/XrmFramework.Cli/README.md
+++ b/src/XrmFramework.Cli/README.md
@@ -318,15 +318,31 @@ Tables tracked locally on the left, the columns of whichever one is selected on 
 | `↑` / `↓`, `Tab` | Navigate / switch pane |
 | `Space`, `Enter` | Toggle the selected column's `Select` flag |
 | `R` | Rename the selected column's C# name |
+| `O` | Edit the option set the selected column is tied to (Picklist, State, Status...) |
 | `Esc`, `Q` | Quit |
 
 Every toggle or rename is validated (same duplicate-name rule as `columns set --name`) and saved
 to disk immediately — there is no separate save step.
 
+`O` on a column with no option set, or one never pulled locally (no matching entry under any
+tracked `.table`'s `Enums`), reports why instead of opening anything. Otherwise it opens a second
+screen — the interactive counterpart of `tables optionsets set` — over that option set's members:
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Navigate members |
+| `Enter`, `R` | Rename the selected member's C# name |
+| `N` | Rename the option set's own C# name |
+| `Esc`, `Q` | Close, back to the columns screen |
+
+A global option set can be declared in several `.table` files at once; a rename here reaches
+every copy the same way `tables optionsets set` does, skipping (and reporting) any copy marked
+`Locked` — its name belongs to the framework package's own generated code.
+
 Requires a real terminal (not redirected output); on an unsupported terminal, prefer the
 non-interactive `tables columns`/`tables optionsets` commands.
 
-Implementation: [`TableEditorApp` / `TableEditorWindow`](Tui)
+Implementation: [`TableEditorApp` / `TableEditorWindow` / `OptionSetEditorWindow`](Tui)
 -> [`TableFileStore`](../XrmFramework.DeployUtils/TableSync/TableFileStore.cs)
 + [`ProjectConfigLocator`](../XrmFramework.DeployUtils/TableSync/ProjectConfigLocator.cs).
 

--- a/src/XrmFramework.Cli/README.md
+++ b/src/XrmFramework.Cli/README.md
@@ -301,17 +301,19 @@ Implementation: [`ColumnHelper`](../XrmFramework.DeployUtils/TableSync/ColumnHel
 
 ### `xrmframework tables edit` ✅ *(available)* — full-screen interactive editor
 
-The interactive counterpart of `tables columns add`/`set`: a full-screen, keyboard-driven
+The interactive counterpart of `tables columns add`/`set`/`pull`: a full-screen, keyboard-driven
 console UI ([Terminal.Gui](https://github.com/gui-cs/Terminal.Gui)) over the locally tracked
 `.table` files, for when you'd rather browse than remember exact table/column logical names.
-Entirely offline, same [`TableFileStore`](../XrmFramework.DeployUtils/TableSync/TableFileStore.cs)
-as every other `tables` command underneath.
+Editing is entirely offline, same [`TableFileStore`](../XrmFramework.DeployUtils/TableSync/TableFileStore.cs)
+as every other `tables` command underneath; pulling (`P`) is the one thing that talks to the
+environment, and does so exactly like `tables pull` on the command line.
 
 ```
 xrmframework tables edit [--tables-dir <DIRECTORY>] [--project-root <DIR>]
 ```
 
-Tables tracked locally on the left, the columns of whichever one is selected on the right:
+Tables tracked locally on the left, the columns of whichever one is selected on the right — the
+left pane starts empty on a brand-new project, `P` is all it takes to populate it:
 
 | Key | Action |
 |---|---|
@@ -319,7 +321,16 @@ Tables tracked locally on the left, the columns of whichever one is selected on 
 | `Space`, `Enter` | Toggle the selected column's `Select` flag |
 | `R` | Rename the selected column's C# name |
 | `O` | Edit the option set the selected column is tied to (Picklist, State, Status...) |
+| `P` | Pull from the environment — update tracked tables, or import new ones |
 | `Esc`, `Q` | Quit |
+
+`P` asks which of the two: **update tracked** re-pulls every table already tracked (`tables pull`
+with no criteria), **import new** shows every table in the environment (flagging what's already
+tracked, like `tables list`) and prompts for the logical name(s) to add. Either way, the screen
+exits for the duration of the pull — it is a network call with its own confirmation prompt and
+progress output, already built on the normal scrolling console in
+[`CrmTableHelper`](../XrmFramework.DeployUtils/TableSync/CrmTableHelper.cs) — then reopens
+afterward over whatever landed on disk.
 
 Every toggle or rename is validated (same duplicate-name rule as `columns set --name`) and saved
 to disk immediately — there is no separate save step.
@@ -344,6 +355,7 @@ non-interactive `tables columns`/`tables optionsets` commands.
 
 Implementation: [`TableEditorApp` / `TableEditorWindow` / `OptionSetEditorWindow`](Tui)
 -> [`TableFileStore`](../XrmFramework.DeployUtils/TableSync/TableFileStore.cs)
++ [`CrmTableHelper`](../XrmFramework.DeployUtils/TableSync/CrmTableHelper.cs) (`P`)
 + [`ProjectConfigLocator`](../XrmFramework.DeployUtils/TableSync/ProjectConfigLocator.cs).
 
 ### `xrmframework tables optionsets` ✅ *(available)* — rename option sets and their members

--- a/src/XrmFramework.Cli/Tui/OptionSetEditorWindow.cs
+++ b/src/XrmFramework.Cli/Tui/OptionSetEditorWindow.cs
@@ -1,0 +1,267 @@
+// Copyright (c) Christophe Gondouin (CGO Conseils). All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Data;
+using Terminal.Gui;
+using XrmFramework.Core;
+using XrmFramework.DeployUtils.TableSync;
+// XrmFramework.Core also declares a Key type (.table alternate keys) — alias Terminal.Gui's.
+using GuiKey = Terminal.Gui.Key;
+
+namespace XrmFramework.Cli.Tui;
+
+/// <summary>
+/// Full-screen editor for one option set's C# name and its members' names, opened from
+/// <see cref="TableEditorWindow" /> (<c>O</c> on a column tied to one). The interactive
+/// counterpart of <c>tables optionsets set</c>: same rule set, applied and saved immediately
+/// through <see cref="TableFileStore.Save" /> instead of a <c>--option</c>/<c>--value</c> pair
+/// on the command line.
+/// </summary>
+/// <remarks>
+/// A global option set can be declared in several <c>.table</c> files at once — the historical
+/// DefinitionManager wrote it into every table whose column referenced it, plus the shared
+/// <c>OptionSets.table</c>. A rename here walks every copy in <see cref="_allTables" /> the same
+/// way <c>OptionSetHelper.Set</c> does, skipping (and reporting) any copy marked <c>Locked</c>:
+/// its name belongs to the framework package's own generated code.
+/// </remarks>
+internal sealed class OptionSetEditorWindow : Window
+{
+    private const string HelpText = "↑/↓ navigate    Enter/R rename value    N rename option set    Esc/Q close";
+
+    private readonly IReadOnlyList<TrackedTable> _allTables;
+    private readonly string _logicalName;
+    private readonly TableView _valuesTable;
+    private readonly Label _status;
+
+    private List<OptionSetEnumValue> _sortedValues = new();
+    private OptionSetEnum _reference = null!;
+
+    public OptionSetEditorWindow(IReadOnlyList<TrackedTable> allTables, string logicalName)
+        : base($"Option set — {logicalName}")
+    {
+        _allTables = allTables;
+        _logicalName = logicalName;
+
+        _valuesTable = new TableView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1),
+            FullRowSelect = true
+        };
+
+        _status = new Label
+        {
+            X = 0,
+            Y = Pos.Bottom(_valuesTable),
+            Width = Dim.Fill(),
+            Height = 1
+        };
+
+        Add(_valuesTable, _status);
+
+        _valuesTable.KeyPress += ValuesTable_KeyPress;
+
+        SetStatus(null);
+        LoadValues();
+    }
+
+    public override bool ProcessKey(KeyEvent keyEvent)
+    {
+        if (keyEvent.Key is GuiKey.Esc or GuiKey.q or GuiKey.Q)
+        {
+            Application.RequestStop();
+            return true;
+        }
+
+        if (keyEvent.Key is GuiKey.n or GuiKey.N)
+        {
+            RenameEnum();
+            return true;
+        }
+
+        return base.ProcessKey(keyEvent);
+    }
+
+    /// <remarks>
+    /// Every tracked file that declares this logical name, whether or not it is the one the
+    /// column being edited belongs to — same lookup as <c>OptionSetHelper.FindCopies</c>.
+    /// </remarks>
+    private List<(TrackedTable Tracked, OptionSetEnum Enum)> FindCopies()
+        => _allTables
+            .Select(t => (Tracked: t, Enum: t.Table.Enums.FirstOrDefault(
+                e => string.Equals(e?.LogicalName, _logicalName, StringComparison.OrdinalIgnoreCase))))
+            .Where(x => x.Enum != null)
+            .Select(x => (x.Tracked, Enum: x.Enum!))
+            .ToList();
+
+    private void LoadValues()
+    {
+        // Members are metadata, not identifiers a project renames per copy: any copy carries the
+        // same values, so the first one is representative — same choice as
+        // OptionSetHelper.ListMembers. The C# name can legitimately disagree between copies
+        // (a rename here corrects that), so re-reading it after every save keeps the title honest.
+        _reference = FindCopies()[0].Enum;
+        _sortedValues = _reference.Values.OrderBy(v => v.Value).ToList();
+        _valuesTable.Table = BuildDataTable();
+        RefreshTitle();
+    }
+
+    private DataTable BuildDataTable()
+    {
+        var data = new DataTable();
+        data.Columns.Add("Value");
+        data.Columns.Add("C# name");
+        data.Columns.Add("External value");
+
+        foreach (var value in _sortedValues)
+            data.Rows.Add(value.Value.ToString(), value.Name ?? string.Empty, value.ExternalValue ?? string.Empty);
+
+        return data;
+    }
+
+    private void RefreshTitle()
+    {
+        var tag = _reference.IsGlobal ? " (global)" : string.Empty;
+        Title = $"Option set — {_logicalName}{tag} — {_reference.Name}";
+    }
+
+    private void ValuesTable_KeyPress(View.KeyEventEventArgs e)
+    {
+        var row = _valuesTable.SelectedRow;
+        if (row < 0 || row >= _sortedValues.Count)
+            return;
+
+        if (e.KeyEvent.Key is GuiKey.Enter or GuiKey.r or GuiKey.R)
+        {
+            RenameValue(row);
+            e.Handled = true;
+        }
+    }
+
+    private void RenameEnum()
+    {
+        var newName = Prompts.AskText($"Rename option set {_logicalName}", "C# name:", _reference.Name ?? string.Empty);
+        if (newName == null || string.Equals(newName, _reference.Name, StringComparison.Ordinal))
+            return;
+
+        if (string.IsNullOrWhiteSpace(newName))
+        {
+            Prompts.ShowError("The C# name cannot be empty.");
+            return;
+        }
+
+        Apply(newEnumName: newName, valueNumber: null, newValueName: null);
+    }
+
+    private void RenameValue(int row)
+    {
+        var value = _sortedValues[row];
+
+        var newName = Prompts.AskText($"Rename value {value.Value}", "C# name:", value.Name ?? string.Empty);
+        if (newName == null || string.Equals(newName, value.Name, StringComparison.Ordinal))
+            return;
+
+        if (string.IsNullOrWhiteSpace(newName))
+        {
+            Prompts.ShowError("The C# name cannot be empty.");
+            return;
+        }
+
+        Apply(newEnumName: null, valueNumber: value.Value, newValueName: newName);
+    }
+
+    /// <remarks>
+    /// Mirrors <c>OptionSetHelper.Set</c>'s loop exactly (locked copies skipped and reported,
+    /// per-copy revert if a save fails), just against the already-loaded <see cref="_allTables" />
+    /// instead of re-reading every file from disk.
+    /// </remarks>
+    private void Apply(string? newEnumName, int? valueNumber, string? newValueName)
+    {
+        var touched = new List<string>();
+        var frozen = new List<string>();
+        var errors = new List<string>();
+        var valueFound = false;
+
+        foreach (var (tracked, enumEntry) in FindCopies())
+        {
+            if (enumEntry.IsLocked)
+            {
+                frozen.Add(Path.GetFileName(tracked.Path));
+                continue;
+            }
+
+            var previousEnumName = enumEntry.Name;
+            OptionSetEnumValue? member = null;
+            string? previousValueName = null;
+            var changed = false;
+
+            if (newEnumName != null && !string.Equals(enumEntry.Name, newEnumName, StringComparison.Ordinal))
+            {
+                enumEntry.Name = newEnumName;
+                changed = true;
+            }
+
+            if (valueNumber.HasValue)
+            {
+                member = enumEntry.Values.FirstOrDefault(v => v.Value == valueNumber.Value);
+
+                if (member != null)
+                {
+                    valueFound = true;
+                    previousValueName = member.Name;
+
+                    if (!string.Equals(member.Name, newValueName, StringComparison.Ordinal))
+                    {
+                        member.Name = newValueName;
+                        changed = true;
+                    }
+                }
+            }
+
+            if (!changed)
+                continue;
+
+            try
+            {
+                TableFileStore.Save(tracked.Path, tracked.Table);
+                touched.Add(Path.GetFileName(tracked.Path));
+            }
+            catch (Exception ex)
+            {
+                enumEntry.Name = previousEnumName;
+                if (member != null)
+                    member.Name = previousValueName;
+
+                errors.Add($"{Path.GetFileName(tracked.Path)}: {ex.Message}");
+            }
+        }
+
+        LoadValues();
+
+        if (errors.Count > 0)
+        {
+            Prompts.ShowError(string.Join("\n", errors));
+            return;
+        }
+
+        if (valueNumber.HasValue && !valueFound)
+        {
+            SetStatus($"No member valued {valueNumber.Value} in {_logicalName}.");
+            return;
+        }
+
+        if (touched.Count == 0)
+        {
+            SetStatus(frozen.Count > 0 ? $"Frozen in {string.Join(", ", frozen)}; nothing else to change." : "Nothing to change.");
+            return;
+        }
+
+        var summary = $"Updated {touched.Count} file(s): {string.Join(", ", touched)}.";
+        SetStatus(frozen.Count > 0 ? $"{summary} Kept frozen in {string.Join(", ", frozen)}." : summary);
+    }
+
+    private void SetStatus(string? message)
+        => _status.Text = string.IsNullOrEmpty(message) ? HelpText : $"{message}   {HelpText}";
+}

--- a/src/XrmFramework.Cli/Tui/Prompts.cs
+++ b/src/XrmFramework.Cli/Tui/Prompts.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Christophe Gondouin (CGO Conseils). All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Terminal.Gui;
+
+namespace XrmFramework.Cli.Tui;
+
+/// <summary>
+/// Small modal dialogs shared by <see cref="TableEditorWindow" /> and
+/// <see cref="OptionSetEditorWindow" />.
+/// </summary>
+internal static class Prompts
+{
+    /// <summary>
+    /// A single text field in a modal dialog. Esc or the Cancel button return
+    /// <see langword="null" />; OK returns whatever the field holds, blank included — the caller
+    /// decides whether blank is valid.
+    /// </summary>
+    public static string? AskText(string dialogTitle, string label, string initialValue)
+    {
+        var input = new TextField(initialValue) { X = 0, Y = 1, Width = Dim.Fill() };
+        var promptLabel = new Label(label) { X = 0, Y = 0 };
+
+        var okButton = new Button("OK", true);
+        var cancelButton = new Button("Cancel", false);
+
+        var dialog = new Dialog(dialogTitle, 60, 7, okButton, cancelButton);
+        dialog.Add(promptLabel, input);
+
+        string? result = null;
+        okButton.Clicked += () =>
+        {
+            result = input.Text.ToString();
+            Application.RequestStop();
+        };
+        cancelButton.Clicked += () => Application.RequestStop();
+        dialog.KeyPress += e =>
+        {
+            if (e.KeyEvent.Key == Key.Esc)
+            {
+                Application.RequestStop();
+                e.Handled = true;
+            }
+        };
+
+        input.SetFocus();
+        Application.Run(dialog);
+
+        return result;
+    }
+
+    public static void ShowError(string message) => MessageBox.ErrorQuery("Error", message, "OK");
+}

--- a/src/XrmFramework.Cli/Tui/TableEditorApp.cs
+++ b/src/XrmFramework.Cli/Tui/TableEditorApp.cs
@@ -16,15 +16,34 @@ namespace XrmFramework.Cli.Tui;
 internal sealed record TrackedTable(string Path, CoreTable Table);
 
 /// <summary>
+/// What <see cref="TableEditorWindow" /> asked for when it requested a pull, read back by
+/// <see cref="TableEditorApp.Run" /> once <c>Application.Run</c> returns.
+/// </summary>
+internal enum PullRequest
+{
+    /// <summary>Re-pull every table already tracked locally — <c>tables pull</c> with no criteria.</summary>
+    UpdateTracked,
+
+    /// <summary>Browse the environment and pick new tables to pull by logical name.</summary>
+    ImportNew
+}
+
+/// <summary>
 /// <c>xrmframework tables edit</c> command: launches a full-screen console editor
 /// (<see cref="TableEditorWindow" />) over the locally tracked <c>.table</c> files — the
-/// interactive counterpart of <c>tables columns list/add/set</c>, entirely offline.
+/// interactive counterpart of <c>tables columns list/add/set</c>, entirely offline except for
+/// <c>P</c> (pull), which briefly hands the terminal back to <see cref="CrmTableHelper" />.
 /// </summary>
 /// <remarks>
 /// Resolution of the tables directory and the initial load are deliberately kept outside
 /// Terminal.Gui: both can fail with a message worth printing to a normal scrolling console,
 /// which stops making sense once <see cref="Application.Init(ConsoleDriver, IMainLoopDriver)" />
-/// has taken over the screen.
+/// has taken over the screen. A pull is the same story once it is running: it is a network call
+/// with its own confirmation prompt and progress lines, already built entirely on
+/// <c>AnsiConsole</c> in <see cref="CrmTableHelper" /> — reusing it as is (rather than
+/// re-implementing a progress UI inside Terminal.Gui) means <c>tables edit</c> exits its own
+/// screen for the duration of the pull, then reopens over whatever
+/// <see cref="CrmTableHelper.Pull" /> left on disk.
 /// </remarks>
 public static class TableEditorApp
 {
@@ -37,31 +56,83 @@ public static class TableEditorApp
         if (directory == null)
             return ExitNotFound;
 
-        // The full set, OptionSets.table (the global option sets pseudo-table) included: a
-        // global option set can be declared in several files at once, and renaming it has to
-        // walk all of them the same way "tables optionsets set" does — TableEditorWindow only
-        // browses the subset with actual columns.
-        var allTables = LoadLocalTables(directory);
-        var browsableTables = allTables.Where(t => !IsGlobalOptionSetsPseudoTable(t.Table)).ToList();
-
-        if (browsableTables.Count == 0)
+        while (true)
         {
-            AnsiConsole.MarkupLine($"[yellow]No .table file found in[/] {Markup.Escape(directory)}.");
-            return ExitSuccess;
-        }
+            // The full set, OptionSets.table (the global option sets pseudo-table) included: a
+            // global option set can be declared in several files at once, and renaming it has to
+            // walk all of them the same way "tables optionsets set" does — TableEditorWindow only
+            // browses the subset with actual columns.
+            var allTables = LoadLocalTables(directory);
+            var browsableTables = allTables.Where(t => !IsGlobalOptionSetsPseudoTable(t.Table)).ToList();
 
-        Application.Init();
-        try
-        {
-            Application.Run(new TableEditorWindow(browsableTables, allTables));
-        }
-        finally
-        {
-            Application.Shutdown();
-        }
+            TableEditorWindow window;
 
-        return ExitSuccess;
+            Application.Init();
+            try
+            {
+                window = new TableEditorWindow(browsableTables, allTables);
+                Application.Run(window);
+            }
+            finally
+            {
+                // TableEditorWindow's constructor points this at itself; clearing it here avoids
+                // a stale closure over a disposed window surviving into whatever runs next.
+                Application.RootKeyEvent = null;
+                Application.Shutdown();
+            }
+
+            if (window.PendingPull == null)
+                return ExitSuccess;
+
+            RunPull(window.PendingPull.Value, projectRoot, directory);
+            // Loop back: re-Init a fresh Terminal.Gui session over whatever the pull left on disk.
+        }
     }
+
+    /// <summary>
+    /// Runs entirely on the plain, non-alternate-screen console — Terminal.Gui has already been
+    /// shut down by the caller. Reuses <see cref="CrmTableHelper" /> verbatim: same environment
+    /// resolution, same confirmation prompt, same per-table progress and error reporting as
+    /// <c>tables pull</c> on the command line.
+    /// </summary>
+    private static void RunPull(PullRequest request, string? projectRoot, string tablesDirectory)
+    {
+        AnsiConsole.WriteLine();
+
+        if (request == PullRequest.ImportNew)
+        {
+            // Shows every table in the environment, flagging what's already tracked — the same
+            // browse step "tables list" offers before typing a --table name by hand.
+            CrmTableHelper.List(projectRoot, prefix: null, filter: null, customOnly: false);
+            AnsiConsole.WriteLine();
+
+            var input = AnsiConsole.Prompt(
+                new TextPrompt<string>("Logical name(s) to import ([grey]comma-separated, empty to cancel[/]):")
+                    .AllowEmpty());
+
+            var names = SplitNames(input);
+            if (names.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[yellow]Nothing to import.[/]");
+            }
+            else
+            {
+                CrmTableHelper.Pull(projectRoot, tablesDirectory, names, prefix: null, noPrompt: false);
+            }
+        }
+        else
+        {
+            CrmTableHelper.Pull(projectRoot, tablesDirectory, tableNames: null, prefix: null, noPrompt: false);
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[grey]Press Enter to return to the editor...[/]");
+        Console.ReadLine();
+    }
+
+    private static List<string> SplitNames(string value)
+        => value.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
 
     /// <remarks>
     /// Mirrors <c>ColumnHelper.ResolveTablesDirectory</c> (kept <c>internal</c> to DeployUtils):

--- a/src/XrmFramework.Cli/Tui/TableEditorApp.cs
+++ b/src/XrmFramework.Cli/Tui/TableEditorApp.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Christophe Gondouin (CGO Conseils). All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Spectre.Console;
+using Terminal.Gui;
+using XrmFramework.DeployUtils.TableSync;
+using CoreTable = XrmFramework.Core.Table;
+
+namespace XrmFramework.Cli.Tui;
+
+/// <summary>
+/// A <c>.table</c> file already tracked locally, paired with the file it was loaded from — the
+/// same pairing <c>ColumnHelper</c>/<c>OptionSetHelper</c> use internally, republished here since
+/// their own is <c>internal</c> to <c>XrmFramework.DeployUtils</c>.
+/// </summary>
+internal sealed record TrackedTable(string Path, CoreTable Table);
+
+/// <summary>
+/// <c>xrmframework tables edit</c> command: launches a full-screen console editor
+/// (<see cref="TableEditorWindow" />) over the locally tracked <c>.table</c> files — the
+/// interactive counterpart of <c>tables columns list/add/set</c>, entirely offline.
+/// </summary>
+/// <remarks>
+/// Resolution of the tables directory and the initial load are deliberately kept outside
+/// Terminal.Gui: both can fail with a message worth printing to a normal scrolling console,
+/// which stops making sense once <see cref="Application.Init(ConsoleDriver, IMainLoopDriver)" />
+/// has taken over the screen.
+/// </remarks>
+public static class TableEditorApp
+{
+    public const int ExitSuccess = 0;
+    public const int ExitNotFound = 2;
+
+    public static int Run(string? projectRoot, string? tablesDirectory)
+    {
+        var directory = ResolveTablesDirectory(projectRoot, tablesDirectory);
+        if (directory == null)
+            return ExitNotFound;
+
+        var tables = LoadLocalTables(directory);
+        if (tables.Count == 0)
+        {
+            AnsiConsole.MarkupLine($"[yellow]No .table file found in[/] {Markup.Escape(directory)}.");
+            return ExitSuccess;
+        }
+
+        Application.Init();
+        try
+        {
+            Application.Run(new TableEditorWindow(tables));
+        }
+        finally
+        {
+            Application.Shutdown();
+        }
+
+        return ExitSuccess;
+    }
+
+    /// <remarks>
+    /// Mirrors <c>ColumnHelper.ResolveTablesDirectory</c> (kept <c>internal</c> to DeployUtils):
+    /// same <c>--tables-dir</c> override, same <see cref="ProjectConfigLocator" /> fallback.
+    /// </remarks>
+    private static string? ResolveTablesDirectory(string? projectRoot, string? tablesDirectory)
+    {
+        var location = ProjectConfigLocator.Locate(projectRoot ?? Directory.GetCurrentDirectory());
+
+        var directory = tablesDirectory ?? location?.TablesDirectory;
+
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            AnsiConsole.MarkupLine(
+                "[red]Unable to infer the .table directory.[/] " +
+                "Declare [cyan]XrmFrameworkCoreProjectName[/] in the root's " +
+                "Directory.Build.props, or pass [cyan]--tables-dir[/].");
+            return null;
+        }
+
+        if (!Directory.Exists(directory))
+        {
+            AnsiConsole.MarkupLine($"[red]Directory not found:[/] {Markup.Escape(directory)}");
+            return null;
+        }
+
+        return directory;
+    }
+
+    /// <remarks>
+    /// Mirrors <c>ColumnHelper.LoadLocalTables(directory, includeGlobalOptionSets: false)</c>
+    /// (kept <c>internal</c>): same skip of unreadable files and of the global option sets
+    /// pseudo-table, which describes no entity and so carries no column to edit.
+    /// </remarks>
+    private static List<TrackedTable> LoadLocalTables(string directory)
+    {
+        var result = new List<TrackedTable>();
+
+        foreach (var path in Directory.GetFiles(directory, "*" + TableFileStore.TableFileExtension)
+                                       .OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+        {
+            CoreTable table;
+            try
+            {
+                table = TableFileStore.Load(path);
+            }
+            catch (Exception)
+            {
+                continue;
+            }
+
+            if (string.Equals(table.LogicalName, TableFileStore.GlobalOptionSetLogicalName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            result.Add(new TrackedTable(path, table));
+        }
+
+        return result.OrderBy(t => t.Table.LogicalName, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+}

--- a/src/XrmFramework.Cli/Tui/TableEditorApp.cs
+++ b/src/XrmFramework.Cli/Tui/TableEditorApp.cs
@@ -37,8 +37,14 @@ public static class TableEditorApp
         if (directory == null)
             return ExitNotFound;
 
-        var tables = LoadLocalTables(directory);
-        if (tables.Count == 0)
+        // The full set, OptionSets.table (the global option sets pseudo-table) included: a
+        // global option set can be declared in several files at once, and renaming it has to
+        // walk all of them the same way "tables optionsets set" does — TableEditorWindow only
+        // browses the subset with actual columns.
+        var allTables = LoadLocalTables(directory);
+        var browsableTables = allTables.Where(t => !IsGlobalOptionSetsPseudoTable(t.Table)).ToList();
+
+        if (browsableTables.Count == 0)
         {
             AnsiConsole.MarkupLine($"[yellow]No .table file found in[/] {Markup.Escape(directory)}.");
             return ExitSuccess;
@@ -47,7 +53,7 @@ public static class TableEditorApp
         Application.Init();
         try
         {
-            Application.Run(new TableEditorWindow(tables));
+            Application.Run(new TableEditorWindow(browsableTables, allTables));
         }
         finally
         {
@@ -86,9 +92,10 @@ public static class TableEditorApp
     }
 
     /// <remarks>
-    /// Mirrors <c>ColumnHelper.LoadLocalTables(directory, includeGlobalOptionSets: false)</c>
-    /// (kept <c>internal</c>): same skip of unreadable files and of the global option sets
-    /// pseudo-table, which describes no entity and so carries no column to edit.
+    /// Mirrors <c>ColumnHelper.LoadLocalTables(directory, includeGlobalOptionSets: true)</c>
+    /// (kept <c>internal</c>): same skip of unreadable files. Unlike that default, the pseudo-table
+    /// is kept here — option set edits need every file that might declare a copy, callers that
+    /// only want browsable tables filter it out via <see cref="IsGlobalOptionSetsPseudoTable" />.
     /// </remarks>
     private static List<TrackedTable> LoadLocalTables(string directory)
     {
@@ -107,12 +114,12 @@ public static class TableEditorApp
                 continue;
             }
 
-            if (string.Equals(table.LogicalName, TableFileStore.GlobalOptionSetLogicalName, StringComparison.OrdinalIgnoreCase))
-                continue;
-
             result.Add(new TrackedTable(path, table));
         }
 
         return result.OrderBy(t => t.Table.LogicalName, StringComparer.OrdinalIgnoreCase).ToList();
     }
+
+    internal static bool IsGlobalOptionSetsPseudoTable(CoreTable table)
+        => string.Equals(table.LogicalName, TableFileStore.GlobalOptionSetLogicalName, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/XrmFramework.Cli/Tui/TableEditorWindow.cs
+++ b/src/XrmFramework.Cli/Tui/TableEditorWindow.cs
@@ -20,7 +20,7 @@ namespace XrmFramework.Cli.Tui;
 /// </summary>
 internal sealed class TableEditorWindow : Window
 {
-    private const string HelpText = "↑/↓ navigate    Space/Enter toggle    R rename    O option set    Esc/Q quit";
+    private const string HelpText = "↑/↓ navigate    Space/Enter toggle    R rename    O option set    P pull    Esc/Q quit";
 
     private readonly IReadOnlyList<TrackedTable> _tables;
     private readonly IReadOnlyList<TrackedTable> _allTables;
@@ -31,6 +31,13 @@ internal sealed class TableEditorWindow : Window
 
     private List<Column> _sortedColumns = new();
     private TrackedTable? _current;
+
+    /// <summary>
+    /// Set by <see cref="RequestPull" /> and read back by <c>TableEditorApp.Run</c> once this
+    /// window's <c>Application.Run</c> call returns — <see langword="null" /> means the user
+    /// quit normally, no pull requested.
+    /// </summary>
+    public PullRequest? PendingPull { get; private set; }
 
     /// <param name="tables">Browsable, left-pane tables — those with columns to edit.</param>
     /// <param name="allTables">
@@ -94,27 +101,74 @@ internal sealed class TableEditorWindow : Window
         _tableList.SelectedItemChanged += args => LoadColumns(args.Item);
         _columnTable.KeyPress += ColumnTable_KeyPress;
 
-        SetStatus(null);
+        // Global shortcuts (quit, pull) via RootKeyEvent rather than an overridden ProcessKey:
+        // when the Tables pane (a ListView) has focus, its own key handling — including the
+        // incremental "jump to item" search on plain letters — consumes the event before it
+        // would ever bubble up to this Window, so Q/P (and, from that pane, even Esc) silently
+        // do nothing. RootKeyEvent fires before any view gets a look, so it works regardless of
+        // which pane has focus. Application.Current is checked to leave it inert while a modal
+        // (rename dialog, option set editor...) is on top — otherwise typing a name containing
+        // 'q' would close whatever dialog is open on the first such letter.
+        Application.RootKeyEvent = HandleGlobalKey;
 
         if (_tables.Count > 0)
+        {
+            SetStatus(null);
             LoadColumns(0);
+        }
+        else
+        {
+            SetStatus("No table tracked yet — press P to pull from the environment.");
+        }
     }
 
-    /// <remarks>
-    /// Global quit shortcut. Overriding here (rather than a <c>KeyPress</c> handler) relies on
-    /// the normal Terminal.Gui key routing: whichever pane has focus gets first chance to handle
-    /// the key (the rename dialog runs as its own modal Toplevel, so it never reaches this
-    /// override), and only an unhandled key bubbles up to the Window itself.
-    /// </remarks>
-    public override bool ProcessKey(KeyEvent keyEvent)
+    private bool HandleGlobalKey(KeyEvent keyEvent)
     {
+        // Inert while any other Toplevel (a dialog, the option set editor...) is on top: those
+        // handle their own Esc, and letters must reach a focused TextField untouched.
+        if (Application.Current != this)
+            return false;
+
         if (keyEvent.Key is GuiKey.Esc or GuiKey.q or GuiKey.Q)
         {
             Application.RequestStop();
             return true;
         }
 
-        return base.ProcessKey(keyEvent);
+        if (keyEvent.Key is GuiKey.p or GuiKey.P)
+        {
+            RequestPull();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Asks which kind of pull to run, then quits this window with <see cref="PendingPull" /> set
+    /// so <c>TableEditorApp.Run</c> performs it — a pull is a network call with its own
+    /// confirmation and progress output, which needs the plain console, not this screen. Nothing
+    /// happens locally until control returns there.
+    /// </summary>
+    private void RequestPull()
+    {
+        var choice = MessageBox.Query(
+            "Pull from environment",
+            "Update every table already tracked, or browse the environment for new ones to import?",
+            "Update tracked", "Import new...", "Cancel");
+
+        switch (choice)
+        {
+            case 0:
+                PendingPull = PullRequest.UpdateTracked;
+                Application.RequestStop();
+                break;
+
+            case 1:
+                PendingPull = PullRequest.ImportNew;
+                Application.RequestStop();
+                break;
+        }
     }
 
     private static string FormatTableEntry(TrackedTable tracked)

--- a/src/XrmFramework.Cli/Tui/TableEditorWindow.cs
+++ b/src/XrmFramework.Cli/Tui/TableEditorWindow.cs
@@ -20,9 +20,10 @@ namespace XrmFramework.Cli.Tui;
 /// </summary>
 internal sealed class TableEditorWindow : Window
 {
-    private const string HelpText = "↑/↓ navigate    Space/Enter toggle    R rename    Esc/Q quit";
+    private const string HelpText = "↑/↓ navigate    Space/Enter toggle    R rename    O option set    Esc/Q quit";
 
     private readonly IReadOnlyList<TrackedTable> _tables;
+    private readonly IReadOnlyList<TrackedTable> _allTables;
     private readonly ListView _tableList;
     private readonly FrameView _columnsFrame;
     private readonly TableView _columnTable;
@@ -31,10 +32,17 @@ internal sealed class TableEditorWindow : Window
     private List<Column> _sortedColumns = new();
     private TrackedTable? _current;
 
-    public TableEditorWindow(IReadOnlyList<TrackedTable> tables)
+    /// <param name="tables">Browsable, left-pane tables — those with columns to edit.</param>
+    /// <param name="allTables">
+    /// Every locally tracked file, the global option sets pseudo-table included: an option set
+    /// rename (<see cref="EditOptionSet" />) has to reach every copy, the same way
+    /// <c>tables optionsets set</c> does.
+    /// </param>
+    public TableEditorWindow(IReadOnlyList<TrackedTable> tables, IReadOnlyList<TrackedTable> allTables)
         : base("XrmFramework — tables edit")
     {
         _tables = tables;
+        _allTables = allTables;
 
         var tablesFrame = new FrameView
         {
@@ -179,6 +187,12 @@ internal sealed class TableEditorWindow : Window
                 RenameSelected(row);
                 e.Handled = true;
                 break;
+
+            case GuiKey.o:
+            case GuiKey.O:
+                EditOptionSet(row);
+                e.Handled = true;
+                break;
         }
     }
 
@@ -243,36 +257,37 @@ internal sealed class TableEditorWindow : Window
     }
 
     private static string? PromptForName(Column column)
+        => Prompts.AskText($"Rename {column.LogicalName}", "New C# name:", column.Name);
+
+    /// <summary>
+    /// Opens <see cref="OptionSetEditorWindow" /> on the option set the selected column
+    /// references, if any. A column not tied to one (<see cref="Column.EnumName" /> empty) or
+    /// one whose option set was never pulled locally (no matching entry in
+    /// <see cref="XrmFramework.Core.Table.Enums" /> anywhere in <see cref="_allTables" />) just
+    /// reports why instead of opening anything.
+    /// </summary>
+    private void EditOptionSet(int row)
     {
-        var input = new TextField(column.Name) { X = 0, Y = 1, Width = Dim.Fill() };
-        var label = new Label("New C# name:") { X = 0, Y = 0 };
+        var column = _sortedColumns[row];
 
-        var okButton = new Button("OK", true);
-        var cancelButton = new Button("Cancel", false);
-
-        var dialog = new Dialog($"Rename {column.LogicalName}", 60, 7, okButton, cancelButton);
-        dialog.Add(label, input);
-
-        string? result = null;
-        okButton.Clicked += () =>
+        if (string.IsNullOrEmpty(column.EnumName))
         {
-            result = input.Text.ToString();
-            Application.RequestStop();
-        };
-        cancelButton.Clicked += () => Application.RequestStop();
-        dialog.KeyPress += e =>
+            SetStatus($"{column.LogicalName} is not tied to an option set.");
+            return;
+        }
+
+        var known = _allTables.Any(t => t.Table.Enums.Any(
+            e => string.Equals(e?.LogicalName, column.EnumName, StringComparison.OrdinalIgnoreCase)));
+
+        if (!known)
         {
-            if (e.KeyEvent.Key == GuiKey.Esc)
-            {
-                Application.RequestStop();
-                e.Handled = true;
-            }
-        };
+            ShowError(
+                $"No option set definition tracked locally for '{column.EnumName}'. " +
+                "Run 'tables optionsets list' or 'tables pull' first.");
+            return;
+        }
 
-        input.SetFocus();
-        Application.Run(dialog);
-
-        return result;
+        Application.Run(new OptionSetEditorWindow(_allTables, column.EnumName));
     }
 
     private bool TrySave(out string? error)
@@ -290,7 +305,7 @@ internal sealed class TableEditorWindow : Window
         }
     }
 
-    private static void ShowError(string message) => MessageBox.ErrorQuery("Error", message, "OK");
+    private static void ShowError(string message) => Prompts.ShowError(message);
 
     private void SetStatus(string? message)
         => _status.Text = string.IsNullOrEmpty(message) ? HelpText : $"{message}   {HelpText}";

--- a/src/XrmFramework.Cli/Tui/TableEditorWindow.cs
+++ b/src/XrmFramework.Cli/Tui/TableEditorWindow.cs
@@ -1,0 +1,297 @@
+// Copyright (c) Christophe Gondouin (CGO Conseils). All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Data;
+using Terminal.Gui;
+using XrmFramework.Core;
+using XrmFramework.DeployUtils.TableSync;
+// XrmFramework.Core also declares a Key type (.table alternate keys) — alias Terminal.Gui's.
+using GuiKey = Terminal.Gui.Key;
+
+namespace XrmFramework.Cli.Tui;
+
+/// <summary>
+/// Full-screen editor over the tables passed to it: a list of tracked tables on the left, the
+/// columns of whichever one is selected on the right. Space/Enter toggles a column's
+/// <c>Select</c> flag, <c>R</c> renames its C# name — the same two mutations as
+/// <c>tables columns add</c>/<c>set</c>, applied and saved immediately via
+/// <see cref="TableFileStore.Save" /> instead of requiring a table/column name on the
+/// command line.
+/// </summary>
+internal sealed class TableEditorWindow : Window
+{
+    private const string HelpText = "↑/↓ navigate    Space/Enter toggle    R rename    Esc/Q quit";
+
+    private readonly IReadOnlyList<TrackedTable> _tables;
+    private readonly ListView _tableList;
+    private readonly FrameView _columnsFrame;
+    private readonly TableView _columnTable;
+    private readonly Label _status;
+
+    private List<Column> _sortedColumns = new();
+    private TrackedTable? _current;
+
+    public TableEditorWindow(IReadOnlyList<TrackedTable> tables)
+        : base("XrmFramework — tables edit")
+    {
+        _tables = tables;
+
+        var tablesFrame = new FrameView
+        {
+            Title = "Tables",
+            X = 0,
+            Y = 0,
+            Width = Dim.Percent(34),
+            Height = Dim.Fill(1)
+        };
+
+        _tableList = new ListView(_tables.Select(FormatTableEntry).ToList())
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+        tablesFrame.Add(_tableList);
+
+        _columnsFrame = new FrameView
+        {
+            Title = "Columns",
+            X = Pos.Right(tablesFrame),
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1)
+        };
+
+        _columnTable = new TableView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            FullRowSelect = true
+        };
+        _columnsFrame.Add(_columnTable);
+
+        _status = new Label
+        {
+            X = 0,
+            Y = Pos.Bottom(tablesFrame),
+            Width = Dim.Fill(),
+            Height = 1
+        };
+
+        Add(tablesFrame, _columnsFrame, _status);
+
+        _tableList.SelectedItemChanged += args => LoadColumns(args.Item);
+        _columnTable.KeyPress += ColumnTable_KeyPress;
+
+        SetStatus(null);
+
+        if (_tables.Count > 0)
+            LoadColumns(0);
+    }
+
+    /// <remarks>
+    /// Global quit shortcut. Overriding here (rather than a <c>KeyPress</c> handler) relies on
+    /// the normal Terminal.Gui key routing: whichever pane has focus gets first chance to handle
+    /// the key (the rename dialog runs as its own modal Toplevel, so it never reaches this
+    /// override), and only an unhandled key bubbles up to the Window itself.
+    /// </remarks>
+    public override bool ProcessKey(KeyEvent keyEvent)
+    {
+        if (keyEvent.Key is GuiKey.Esc or GuiKey.q or GuiKey.Q)
+        {
+            Application.RequestStop();
+            return true;
+        }
+
+        return base.ProcessKey(keyEvent);
+    }
+
+    private static string FormatTableEntry(TrackedTable tracked)
+        => $"{tracked.Table.LogicalName,-28} {tracked.Table.Name}";
+
+    private void LoadColumns(int index)
+    {
+        _current = _tables[index];
+
+        _sortedColumns = _current.Table.Columns
+            .OrderBy(c => c.LogicalName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        _columnTable.Table = BuildDataTable(_sortedColumns);
+        RefreshTitle();
+    }
+
+    private static DataTable BuildDataTable(IReadOnlyList<Column> columns)
+    {
+        var data = new DataTable();
+        data.Columns.Add("Sel");
+        data.Columns.Add("Logical name");
+        data.Columns.Add("C# name");
+        data.Columns.Add("Type");
+        data.Columns.Add("Option set");
+
+        foreach (var column in columns)
+        {
+            data.Rows.Add(
+                SelectedMark(column.Selected),
+                column.LogicalName,
+                column.Name,
+                column.Type.ToString(),
+                column.EnumName ?? string.Empty);
+        }
+
+        return data;
+    }
+
+    private static string SelectedMark(bool selected) => selected ? "✓" : string.Empty;
+
+    private void RefreshTitle()
+    {
+        if (_current == null)
+            return;
+
+        var selected = _sortedColumns.Count(c => c.Selected);
+        _columnsFrame.Title = $"Columns — {_current.Table.LogicalName} ({selected}/{_sortedColumns.Count} selected)";
+    }
+
+    private void ColumnTable_KeyPress(View.KeyEventEventArgs e)
+    {
+        if (_current == null)
+            return;
+
+        var row = _columnTable.SelectedRow;
+        if (row < 0 || row >= _sortedColumns.Count)
+            return;
+
+        switch (e.KeyEvent.Key)
+        {
+            case GuiKey.Space:
+            case GuiKey.Enter:
+                ToggleSelected(row);
+                e.Handled = true;
+                break;
+
+            case GuiKey.r:
+            case GuiKey.R:
+                RenameSelected(row);
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void ToggleSelected(int row)
+    {
+        var column = _sortedColumns[row];
+        var previous = column.Selected;
+        column.Selected = !previous;
+
+        if (!TrySave(out var error))
+        {
+            column.Selected = previous;
+            ShowError(error!);
+            return;
+        }
+
+        _columnTable.Table.Rows[row]["Sel"] = SelectedMark(column.Selected);
+        _columnTable.Update();
+        RefreshTitle();
+        SetStatus($"{(column.Selected ? "Activated" : "Deactivated")} {column.LogicalName}.");
+    }
+
+    private void RenameSelected(int row)
+    {
+        var column = _sortedColumns[row];
+
+        var newName = PromptForName(column);
+        if (newName == null || string.Equals(newName, column.Name, StringComparison.Ordinal))
+            return;
+
+        if (string.IsNullOrWhiteSpace(newName))
+        {
+            ShowError("The C# name cannot be empty.");
+            return;
+        }
+
+        // The C# name must stay unique within the table: two columns compiling to the same
+        // identifier would only fail later, at the consuming project's build. Same rule as
+        // ColumnHelper.Set (tables columns set --name).
+        var conflict = _sortedColumns.FirstOrDefault(
+            c => c != column && string.Equals(c.Name, newName, StringComparison.OrdinalIgnoreCase));
+
+        if (conflict != null)
+        {
+            ShowError($"'{newName}' is already used by column {conflict.LogicalName}.");
+            return;
+        }
+
+        var previousName = column.Name;
+        column.Name = newName;
+
+        if (!TrySave(out var error))
+        {
+            column.Name = previousName;
+            ShowError(error!);
+            return;
+        }
+
+        _columnTable.Table.Rows[row]["C# name"] = newName;
+        _columnTable.Update();
+        SetStatus($"Renamed {column.LogicalName}: {previousName} -> {newName}.");
+    }
+
+    private static string? PromptForName(Column column)
+    {
+        var input = new TextField(column.Name) { X = 0, Y = 1, Width = Dim.Fill() };
+        var label = new Label("New C# name:") { X = 0, Y = 0 };
+
+        var okButton = new Button("OK", true);
+        var cancelButton = new Button("Cancel", false);
+
+        var dialog = new Dialog($"Rename {column.LogicalName}", 60, 7, okButton, cancelButton);
+        dialog.Add(label, input);
+
+        string? result = null;
+        okButton.Clicked += () =>
+        {
+            result = input.Text.ToString();
+            Application.RequestStop();
+        };
+        cancelButton.Clicked += () => Application.RequestStop();
+        dialog.KeyPress += e =>
+        {
+            if (e.KeyEvent.Key == GuiKey.Esc)
+            {
+                Application.RequestStop();
+                e.Handled = true;
+            }
+        };
+
+        input.SetFocus();
+        Application.Run(dialog);
+
+        return result;
+    }
+
+    private bool TrySave(out string? error)
+    {
+        try
+        {
+            TableFileStore.Save(_current!.Path, _current.Table);
+            error = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    private static void ShowError(string message) => MessageBox.ErrorQuery("Error", message, "OK");
+
+    private void SetStatus(string? message)
+        => _status.Text = string.IsNullOrEmpty(message) ? HelpText : $"{message}   {HelpText}";
+}

--- a/src/XrmFramework.Cli/XrmFramework.Cli.csproj
+++ b/src/XrmFramework.Cli/XrmFramework.Cli.csproj
@@ -69,6 +69,10 @@
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Spectre.Console.Cli" />
+    <!-- "tables edit" full-screen editor. Confined to the Cli tool (single net10.0 TFM) rather
+         than XrmFramework.DeployUtils: that package also multi-targets net462 for deployment
+         utilities, none of which need a TUI, and Terminal.Gui only ships net8.0+ assets. -->
+    <PackageReference Include="Terminal.Gui" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Adds `xrmframework tables edit`: a full-screen Terminal.Gui console editor over locally tracked `.table` files — browse tables, toggle/rename columns (`Space`/`Enter`, `R`), edit the option sets they reference (`O`: rename the enum's C# name and its members'), and pull from the environment (`P`: update tracked tables, or browse and import new ones).
- Every edit is validated the same way as its `tables columns`/`tables optionsets` command-line equivalent and saved immediately through the same `TableFileStore`; `P` reuses `CrmTableHelper.List`/`Pull` verbatim, exiting the screen for the pull's own confirmation/progress output before reopening.
- Fixes a bug the pull work surfaced: `Esc`/`Q` only quit when the Columns pane had focus — from the Tables pane (a `ListView`), its own keystroke incremental-search silently swallowed every letter and `Esc` before they could reach the window. Replaced with `Application.RootKeyEvent`, gated on `Application.Current` so it stays inert whenever a dialog or the option set editor is on top.
- Deliberately pinned to Terminal.Gui 1.19.0 rather than "latest": 2.0.1+ reorganized the entire public API into a still-settling session/runnable model; 1.19.0 is the long-stable line, ships a net8.0 asset for our net10.0 TFM, and is cross-platform (Windows/macOS/Linux). The dependency is confined to `XrmFramework.Cli` (single net10.0 TFM) rather than `XrmFramework.DeployUtils`, which also multi-targets net462 for deployment utilities that have no use for a TUI.

## Test plan
- [x] `dotnet build` on `XrmFramework.Cli` and its dependency graph — 0 errors.
- [x] Interactive smoke tests driven through a real pseudo-terminal (`expect`), verified against actual `.table` fixtures on disk:
  - [x] Column toggle (`Space`) persists `Select` and round-trips through `TableFileStore`.
  - [x] Column rename (`R`) validates duplicate names and persists.
  - [x] Option set editor (`O`): rename the enum's C# name and a member's name, both persisted.
  - [x] Pull menu (`P`) from any focus state; both "update tracked" and "import new" branches reach `CrmTableHelper.Pull`/`List`; cancel doesn't quit; the exit-TUI → run pull → reopen loop is clean, including the (expected) "no config found" error path.
  - [x] Empty-tables bootstrap: TUI opens with an empty left pane and `P` still works.
  - [x] `Esc`/`Q` quit from every focus state (this was broken from the Tables pane before the `RootKeyEvent` fix).
- [ ] Not tested against a live Dataverse environment (no credentials in this environment) — the pull path is composed entirely of the existing, already-shipped `CrmTableHelper.List`/`Pull` public methods, unmodified.