### PR TITLE
feat(cli): resolve migrate sync-tables name conflicts via the existin…

### DIFF
--- a/src/Tests/XrmFramework.DeployUtils.Tests/TableSync/TableFileSyncerTests.cs
+++ b/src/Tests/XrmFramework.DeployUtils.Tests/TableSync/TableFileSyncerTests.cs
@@ -195,13 +195,14 @@ public class TableFileSyncerTests
 
     [TestCase(false, TestName = "Sync_RefusesTwoNamesForOneTable_HandWrittenCopyFirst")]
     [TestCase(true, TestName = "Sync_RefusesTwoNamesForOneTable_GeneratedCopyFirst")]
-    public void Sync_RefusesTwoNamesForOneTable(bool generatedFirst)
+    public void Sync_RefusesTwoNamesForOneTable_WhenNoTableFileSettlesIt(bool generatedFirst)
     {
         // Which of the two names the project meant cannot be told from here: both classes carry
         // [GeneratedCode("XrmFramework", "2.0")], the 3.1 generator emitting the very same attribute
-        // as the 2.* tool, and the namespace that would separate them never reaches this far.
-        // Electing one would rename a definition out from under its call sites, so the sync stops —
-        // and stops whatever order reflection hands the types back in.
+        // as the 2.* tool, and the namespace that would separate them never reaches this far. With
+        // no .table file yet describing the entity, nothing on disk can settle it either — electing
+        // one would rename a definition out from under its call sites, so the sync stops, whatever
+        // order reflection hands the types back in.
         var handWritten = SystemUserDef();
 
         var generated = SystemUserDef();
@@ -211,9 +212,6 @@ public class TableFileSyncerTests
             ? new[] { generated, handWritten }
             : new[] { handWritten, generated };
 
-        WriteTable("SystemUser", BuildTable("systemuser", "Systemuser", "systemusers",
-            new Column { LogicalName = "systemuserid", Name = "Id", Selected = true }));
-
         var conflict = Assert.Throws<DefinitionNameConflictException>(
             () => new TableFileSyncer(_tempDir).Sync(definitions));
 
@@ -222,9 +220,49 @@ public class TableFileSyncerTests
             conflict.Conflicts.Single().Names.ToArray(),
             "Both names are reported, so one run tells the reader everything to fix.");
 
-        Assert.AreEqual("Systemuser", LoadTable("SystemUser").Name,
-            "Refusing means refusing before writing: the file is left exactly as it was.");
+        Assert.IsFalse(Directory.EnumerateFiles(_tempDir, "*.table").Any(),
+            "Refusing means refusing before writing: nothing was created.");
     }
+
+    [TestCase(false, TestName = "Sync_ResolvesTwoNamesForOneTable_UsingExistingTableFile_HandWrittenCopyFirst")]
+    [TestCase(true, TestName = "Sync_ResolvesTwoNamesForOneTable_UsingExistingTableFile_GeneratedCopyFirst")]
+    public void Sync_ResolvesTwoNamesForOneTable_UsingExistingTableFile(bool generatedFirst)
+    {
+        // A business process flow: its logical name carries the process' GUID, so a .table created
+        // before anyone gave it a nicer name ends up called after that GUID — here, the entity
+        // already has such a file, named "BpfXyz123". Its current Name is necessarily what the 3.1
+        // generator used to emit the BpfXyz123Definition class below, so "BpfLeadToOpportunityProcess"
+        // — the other candidate — is the versioned 2.* class the project's own code refers to, and
+        // the one to keep. The file itself is renamed accordingly, not just its Name field.
+        var handWritten = BpfDef("BpfLeadToOpportunityProcess");
+        var generated = BpfDef("BpfXyz123");
+
+        var definitions = generatedFirst
+            ? new[] { generated, handWritten }
+            : new[] { handWritten, generated };
+
+        WriteTable("BpfXyz123", BuildTable("eco_bpf_xyz123", "BpfXyz123", "eco_bpf_xyz123s",
+            new Column { LogicalName = "eco_bpf_xyz123id", Name = "Id", Selected = true }));
+
+        Assert.DoesNotThrow(() => new TableFileSyncer(_tempDir).Sync(definitions));
+
+        Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "BpfXyz123.table")),
+            "The stale file name must be gone once renamed.");
+
+        var table = LoadTable("BpfLeadToOpportunityProcess");
+        Assert.AreEqual("BpfLeadToOpportunityProcess", table.Name,
+            "The versioned class' name is kept, not the one the generator produced from the old .table.");
+        Assert.IsTrue(table.Columns.Single(c => c.LogicalName == "eco_bpf_xyz123id").Selected);
+    }
+
+    /// <summary>A Bpf* Definition under the given C# name, all describing the same CRM entity.</summary>
+    private static DefinitionInfo BpfDef(string tableName) => new()
+    {
+        TableName = tableName,
+        EntityName = "eco_bpf_xyz123",
+        EntityCollectionName = "eco_bpf_xyz123s",
+        Columns = new List<DefinitionColumnInfo> { new("eco_bpf_xyz123id", "Id") }
+    };
 
     [Test]
     public void Sync_ReportsEveryNameConflict_InOneRun()

--- a/src/XrmFramework.DeployUtils/TableSync/TableFileSyncer.cs
+++ b/src/XrmFramework.DeployUtils/TableSync/TableFileSyncer.cs
@@ -151,11 +151,18 @@ public sealed class TableFileSyncer
     /// Copies that do agree are folded: the file is then written once, and the columns of each are
     /// kept — a column only one of them declares is referenced by the compiled code all the same.
     /// </para>
+    /// <para>
+    /// When the project already tracks the table, its <c>.table</c> file breaks the tie instead of
+    /// stopping the run: the file's current <c>Name</c> is necessarily what the source generator used
+    /// to emit one of the two conflicting classes, so the other candidate is the versioned 2.*
+    /// class the project's own code refers to. See <see cref="ResolveNameFromExistingTableFile"/>.
+    /// </para>
     /// </remarks>
     /// <exception cref="DefinitionNameConflictException">
-    /// At least two definitions describe one table under different names.
+    /// At least two definitions describe one table under different names, and no <c>.table</c> file
+    /// on disk lets this settle which one to keep.
     /// </exception>
-    private static IReadOnlyList<DefinitionInfo> FoldPerTable(IReadOnlyList<DefinitionInfo> definitions)
+    private IReadOnlyList<DefinitionInfo> FoldPerTable(IReadOnlyList<DefinitionInfo> definitions)
     {
         var folded = new List<DefinitionInfo>();
         var conflicts = new List<DefinitionNameConflict>();
@@ -179,29 +186,19 @@ public sealed class TableFileSyncer
 
             if (names.Count > 1)
             {
-                conflicts.Add(new DefinitionNameConflict(copies[0].EntityName, names));
+                var resolvedName = ResolveNameFromExistingTableFile(copies[0].EntityName, names);
+
+                if (resolvedName == null)
+                {
+                    conflicts.Add(new DefinitionNameConflict(copies[0].EntityName, names));
+                    continue;
+                }
+
+                folded.Add(MergeColumns(copies, resolvedName));
                 continue;
             }
 
-            var columns = new List<DefinitionColumnInfo>();
-            var known = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var column in copies.SelectMany(d => d.Columns))
-            {
-                if (column?.LogicalName != null && known.Add(column.LogicalName))
-                    columns.Add(column);
-            }
-
-            folded.Add(new DefinitionInfo
-            {
-                TableName = copies[0].TableName,
-                EntityName = copies.Select(d => d.EntityName).FirstOrDefault(n => !string.IsNullOrEmpty(n))
-                             ?? string.Empty,
-                EntityCollectionName =
-                    copies.Select(d => d.EntityCollectionName).FirstOrDefault(n => !string.IsNullOrEmpty(n)),
-                Columns = columns,
-                IsFullyGenerated = copies.All(d => d.IsFullyGenerated)
-            });
+            folded.Add(MergeColumns(copies, names[0]));
         }
 
         // Every conflict at once: the fix is one edit per table, and reporting them one run at a
@@ -210,6 +207,88 @@ public sealed class TableFileSyncer
             throw new DefinitionNameConflictException(conflicts);
 
         return folded;
+    }
+
+    /// <summary>
+    /// Folds several copies of the same table into one, keeping every column at least one of them
+    /// declares — a column only one references is referenced by the compiled code all the same.
+    /// </summary>
+    private static DefinitionInfo MergeColumns(IReadOnlyList<DefinitionInfo> copies, string tableName)
+    {
+        var columns = new List<DefinitionColumnInfo>();
+        var known = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var column in copies.SelectMany(d => d.Columns))
+        {
+            if (column?.LogicalName != null && known.Add(column.LogicalName))
+                columns.Add(column);
+        }
+
+        return new DefinitionInfo
+        {
+            TableName = tableName,
+            EntityName = copies.Select(d => d.EntityName).FirstOrDefault(n => !string.IsNullOrEmpty(n))
+                         ?? string.Empty,
+            EntityCollectionName =
+                copies.Select(d => d.EntityCollectionName).FirstOrDefault(n => !string.IsNullOrEmpty(n)),
+            Columns = columns,
+            IsFullyGenerated = copies.All(d => d.IsFullyGenerated)
+        };
+    }
+
+    /// <summary>
+    /// Breaks a name conflict using the <c>.table</c> file already on disk for that entity, if any.
+    /// </summary>
+    /// <remarks>
+    /// The only way two classes describe the same table in the analyzed DLL is the migration this
+    /// tool targets: the versioned 2.* <c>*Definition.cs</c> still in source, next to the class the
+    /// 3.1 source generator now emits by reading the <c>.table</c>'s <c>Name</c>. That file's current
+    /// name is therefore necessarily the generator's candidate, not the project's — so when it
+    /// matches exactly one of the two, the other is the name to keep, and the file is renamed to it
+    /// (both the JSON's <c>Name</c> and the file itself) so the generator agrees with it next run.
+    /// Anything less clear-cut — no <c>.table</c> file yet, or its name matching none or several of
+    /// the candidates — is left for <see cref="FoldPerTable"/> to report as an unresolved conflict.
+    /// </remarks>
+    /// <returns>The name to keep, or <see langword="null"/> if the file gives no way to choose.</returns>
+    private string ResolveNameFromExistingTableFile(string entityLogicalName, IReadOnlyList<string> candidateNames)
+    {
+        var path = TableFileStore.FindTableFile(_tablesDirectory, entityLogicalName);
+        if (path == null)
+            return null;
+
+        CoreTable table;
+        try
+        {
+            table = LoadTable(path);
+        }
+        catch (Exception)
+        {
+            // An unreadable file settles nothing; it is reported where it is actually written.
+            return null;
+        }
+
+        var others = candidateNames.Where(n => !string.Equals(n, table.Name, StringComparison.Ordinal)).ToList();
+
+        if (others.Count != 1)
+            return null;
+
+        var resolvedName = others[0];
+        var oldFileName = Path.GetFileNameWithoutExtension(path);
+        var oldName = table.Name;
+
+        table.Name = resolvedName;
+        SaveTable(path, table);
+
+        var newPath = TablePath(resolvedName);
+        if (!string.Equals(path, newPath, StringComparison.OrdinalIgnoreCase))
+            File.Move(path, newPath);
+
+        AnsiConsole.MarkupLine(
+            $"[yellow]Renamed[/] {oldFileName}.table -> [bold]{resolvedName}[/].table " +
+            $"(the DLL also carries {oldName}Definition, generated from this file; kept the " +
+            $"versioned {resolvedName}Definition instead)");
+
+        return resolvedName;
     }
 
     /// <summary>


### PR DESCRIPTION
…g .table file

When two Definition classes describe the same entity under different names (the versioned 2.* class vs the one the 3.1 generator emits from the .table), an existing .table file for that entity now breaks the tie instead of aborting the sync: its current Name is necessarily the generator's candidate, so the other name is the versioned class the project's code refers to. The file is renamed (Name field and the file itself) to that name. Conflicts with no .table file to settle them, or with an ambiguous match, still stop the run as before.
